### PR TITLE
[Solr 5.3.x] Do not delete the webapp directory when restarting solr.

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -661,7 +661,6 @@ def _restart_solr(cluster, host, solrPortBase, pauseBeforeRestart=0):
                 _status('Sleeping for %d seconds before starting Solr node on %s' % (pauseTime, hostAndPort))
                 time.sleep(pauseTime)
         _status('Running start on remote: ' + remoteStartCmd)
-        run('rm -rf '+solrTip+'/'+solrDir+'/solr-webapp/webapp || true')
         _runbg(remoteStartCmd)
         time.sleep(2)
 


### PR DESCRIPTION
In Solr 5.3.0 the war file was removed from the distribution archive: https://issues.apache.org/jira/browse/SOLR-7227

This tool deletes the webapp directory upon restart, expecting it to be regenerated by the extraction of the war file.  With no war file, issuing a restart_solr command using this tool to 5.3.0+ solr installations results in an un-startable solr instance.  (It does start, but it hangs when it can't find the webapp directory.)