### PR TITLE
Apollo 4359 query sampler

### DIFF
--- a/src/main/java/com/lucidworks/QuerySampler.java
+++ b/src/main/java/com/lucidworks/QuerySampler.java
@@ -414,9 +414,9 @@ public class QuerySampler extends AbstractJavaSamplerClient implements Serializa
             if (fusionAuth) {
               fusionPipelineClient =
                       new FusionPipelineClient(fusionEndpoints,
-                              params.get("FUSION_USER"),
-                              params.get("FUSION_PASS"),
-                              params.get("FUSION_REALM"));
+                          params.get("FUSION_USER"),
+                          params.get("FUSION_PASS"),
+                          params.get("FUSION_REALM"));
 
             } else {
               fusionPipelineClient = new FusionPipelineClient(fusionEndpoints);
@@ -469,8 +469,8 @@ public class QuerySampler extends AbstractJavaSamplerClient implements Serializa
 
       if (reporter == null) {
         reporter = ConsoleReporter.forRegistry(metrics)
-                .convertRatesTo(TimeUnit.SECONDS)
-                .convertDurationsTo(TimeUnit.MILLISECONDS).build();
+            .convertRatesTo(TimeUnit.SECONDS)
+            .convertDurationsTo(TimeUnit.MILLISECONDS).build();
         reporter.start(1, TimeUnit.MINUTES);
       }
 

--- a/src/main/java/com/lucidworks/QuerySampler.java
+++ b/src/main/java/com/lucidworks/QuerySampler.java
@@ -413,10 +413,10 @@ public class QuerySampler extends AbstractJavaSamplerClient implements Serializa
           try {
             if (fusionAuth) {
               fusionPipelineClient =
-                      new FusionPipelineClient(fusionEndpoints,
-                          params.get("FUSION_USER"),
-                          params.get("FUSION_PASS"),
-                          params.get("FUSION_REALM"));
+                  new FusionPipelineClient(fusionEndpoints,
+                      params.get("FUSION_USER"),
+                      params.get("FUSION_PASS"),
+                      params.get("FUSION_REALM"));
 
             } else {
               fusionPipelineClient = new FusionPipelineClient(fusionEndpoints);


### PR DESCRIPTION
The following are the changes

* "+" changed to "||" for clause concatenation to reduce the number of "No result" queries. The random int check (<=4) can be made configurable to increase or decrease the % of "No result" queries.

* Poisson delay introduced to re-use the filter queries for a average of 5 seconds (lambda). 