### PR TITLE
SSTK-1 Tag instances created by EMR job flow

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -265,6 +265,7 @@ def _find_all_instances(cloud, onlyIfRunning=True):
 
     return tagged
 
+
 def _find_user_instances(cloud, username, onlyIfRunning=True):
     tagged = {}
     byTag = cloud.get_all_instances(filters={'tag:' + USERNAME_TAG:username})

--- a/fabfile.py
+++ b/fabfile.py
@@ -4106,7 +4106,11 @@ def clean_instances_from_config(clusterId=None):
     cloud = _provider_api(clusterId)
     instance_ids = _cluster_instances(cloud, clusterId)
     if len(instance_ids) > 0:
-        cloud.terminate_instances(instance_ids)
+        all_instances = cloud.get_only_instances(instance_ids)
+        for instance in all_instances:
+            if (instance.state == 'running'):
+                _info("Terminating instance:" + instance.id )
+                cloud.terminate_instances([instance.id])
         _info("Instances are terminated!")
         # update the local config to remove this cluster
         sstk_cfg['clusters'].pop(clusterId, None)

--- a/fabfile.py
+++ b/fabfile.py
@@ -3306,7 +3306,7 @@ def emr_run_indexing_job(emrCluster, solrCluster, collection, pig='s3_to_solr.pi
 
     return stepName
 
-def emr_fusion_indexing_job(emrCluster, fusionCluster, collection='perf', pig='s3://solr-scale-tk/pig/s3_to_fusion.pig', input='s3://solr-scale-tk/pig/output/syn_sample_5m', batch_size='500', reducers='12', region='us-east-1', pipeline=None, thruProxy=True):
+def emr_fusion_indexing_job(emrCluster, fusionCluster, collection='perf', pig='s3_to_fusion.pig', input='s3://solr-scale-tk/pig/output/syn_sample_5m', batch_size='500', reducers='12', region='us-east-1', pipeline=None, thruProxy=True):
     """
     Schedules a Pig job in the specified EMR cluster to index a dataset from S3 into Fusion.
     """

--- a/fabfile.py
+++ b/fabfile.py
@@ -1363,7 +1363,7 @@ def new_ec2_instances(cluster,
                          security_group_ids=[vpcSecurityGroupId])
     
     time.sleep(10) # sometimes the AWS API is a little sluggish in making these instances available to this API
-
+    
     # add a tag to each instance so that we can filter many instances by our cluster tag
 
     now = datetime.datetime.utcnow()

--- a/fabfile.py
+++ b/fabfile.py
@@ -1434,6 +1434,7 @@ def new_ec2_instances(cluster,
     if sstk_cfg.has_key('clusters') is False:
         sstk_cfg['clusters'] = {}
 
+    sstk_cfg['clusters'][cluster] = { 'provider':'ec2', 'name':cluster, 'hosts':hosts, 'username':username }
     _save_config()
 
     _info('\n\n*** %d EC2 instances have been provisioned ***\n\n' % len(hosts))
@@ -3448,7 +3449,6 @@ def fusion_perf_test(cluster, n=3, keepRunning=False, instance_type='r3.2xlarge'
     deploy_config(cluster,'perf','perf')
     deploy_config(cluster,'perf','perf_js')
     _status('Starting Fusion services across cluster ...')
-
     fusion_start(cluster,api=n,connectors=1,ui=n,yjp_path=yjp_path_fusion,apiJavaMem=apiJavaMem)
 
     hosts = _lookup_hosts(cluster)


### PR DESCRIPTION
The current version tags only the EC2 instances created by the script directly. This change is to tag EC2 instances created by EMR job.